### PR TITLE
Use dvh instead of svh for sidebar height

### DIFF
--- a/.changeset/three-cycles-wait.md
+++ b/.changeset/three-cycles-wait.md
@@ -1,0 +1,5 @@
+---
+"@svecodocs/kit": patch
+---
+
+fix: use dvh instead of svh for sidebar height

--- a/packages/kit/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/packages/kit/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -14,8 +14,8 @@
 <main
 	bind:this={ref}
 	class={cn(
-		"bg-background relative flex min-h-svh flex-1 flex-col",
-		"peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+		"bg-background relative flex min-h-dvh flex-1 flex-col",
+		"peer-data-[variant=inset]:min-h-[calc(100dvh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
 		className
 	)}
 	{...restProps}

--- a/packages/kit/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/packages/kit/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -48,7 +48,7 @@
 	<div
 		style="--sidebar-width: {SIDEBAR_WIDTH}; --sidebar-width-icon: {SIDEBAR_WIDTH_ICON}; {style}"
 		class={cn(
-			"group/sidebar-wrapper has-[[data-variant=inset]]:bg-sidebar flex min-h-svh w-full",
+			"group/sidebar-wrapper has-[[data-variant=inset]]:bg-sidebar flex min-h-dvh w-full",
 			className
 		)}
 		bind:this={ref}

--- a/packages/kit/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/packages/kit/src/lib/components/ui/sidebar/sidebar.svelte
@@ -63,7 +63,7 @@
 		<!-- This is what handles the sidebar gap on desktop -->
 		<div
 			class={cn(
-				"w-(--sidebar-width) relative h-svh bg-transparent transition-[width] duration-200 ease-linear",
+				"w-(--sidebar-width) relative h-dvh bg-transparent transition-[width] duration-200 ease-linear",
 				"group-data-[collapsible=offcanvas]:w-0",
 				"group-data-[side=right]:rotate-180",
 				variant === "floating" || variant === "inset"
@@ -73,7 +73,7 @@
 		></div>
 		<div
 			class={cn(
-				"w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-svh transition-[left,right,width] duration-200 ease-linear md:flex",
+				"w-(--sidebar-width) fixed inset-y-0 z-10 hidden h-dvh transition-[left,right,width] duration-200 ease-linear md:flex",
 				side === "left"
 					? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
 					: "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
Fixes blank space beneath the sidebar on mobile safari when the UI is minimized

Before:
<details>

![IMG_0075](https://github.com/user-attachments/assets/5a62c399-725a-443d-b1e1-89ef56e84482)
</details>

After:
<details>

![IMG_0074](https://github.com/user-attachments/assets/dac80b2f-b3c1-4be1-a0cd-16f5e0e4dc43)
</details>
